### PR TITLE
KnockBack Effect for Explosive Crate and Melee Fixed

### DIFF
--- a/Shooter Tutorial/Assets/Prefabs/Explosive Crate.prefab
+++ b/Shooter Tutorial/Assets/Prefabs/Explosive Crate.prefab
@@ -1,0 +1,143 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1017543783673023103
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1017543783673023099}
+  - component: {fileID: 1017543783673023098}
+  - component: {fileID: 1017543783673023097}
+  - component: {fileID: 1017543783673023096}
+  - component: {fileID: 1017543783673022852}
+  m_Layer: 0
+  m_Name: Explosive Crate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1017543783673023099
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017543783673023103}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.13, y: -1.13, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1017543783673023098
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017543783673023103}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 0.9622642, g: 0.077162705, b: 0.077162705, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!70 &1017543783673023097
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017543783673023103}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.16, y: 0.16}
+  m_Direction: 0
+--- !u!50 &1017543783673023096
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017543783673023103}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 15
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &1017543783673022852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1017543783673023103}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ca283021802048d7a78bcfe462c881d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  blastRadius: 1.45
+  enemyLayer:
+    serializedVersion: 2
+    m_Bits: 6144
+  damage: 0
+  explosionForce: 5
+  knockBackDistance: 0.75

--- a/Shooter Tutorial/Assets/Scenes/UItests 1.unity
+++ b/Shooter Tutorial/Assets/Scenes/UItests 1.unity
@@ -381,7 +381,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &485077139
 PrefabInstance:
@@ -399,6 +399,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Layer
       value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 7953915783607088886, guid: d322b4602c8e9434ebf2a1ba514f02de,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
@@ -438,7 +443,7 @@ PrefabInstance:
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
@@ -481,12 +486,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attackPosition: {fileID: 1136710880}
-  attackRange: 0.6
+  attackRange: 0.45
   enemyMask:
     serializedVersion: 2
-    m_Bits: 2048
+    m_Bits: 6144
   damage: 5
-  knockBackEffectStrength: 3500
+  knockBackEffectStrength: 3
 --- !u!4 &520245319 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7436101132885174641, guid: 0d2599c5ce7c7dd40a0381a114ddd5a8,
@@ -586,13 +591,87 @@ RectTransform:
   - {fileID: 1140663254}
   - {fileID: 1746132365}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &707888275
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6760172530793527974, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_Name
+      value: Shooter Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527974, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.986417
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.2514944
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6760172530793527978, guid: f9dd82227aedf3543a4a27de471cb2e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f9dd82227aedf3543a4a27de471cb2e7, type: 3}
 --- !u!1 &1136710879
 GameObject:
   m_ObjectHideFlags: 0
@@ -602,7 +681,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1136710880}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: MeleeAttackPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -617,7 +696,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1136710879}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.142, z: 0}
+  m_LocalPosition: {x: 0, y: 0.121, z: 0}
   m_LocalScale: {x: 0.2, y: 0.2, z: 1}
   m_Children: []
   m_Father: {fileID: 520245319}
@@ -807,6 +886,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 7953915783607088886, guid: d322b4602c8e9434ebf2a1ba514f02de,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -845,7 +929,7 @@ PrefabInstance:
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
@@ -880,6 +964,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: A_
+      objectReference: {fileID: 0}
+    - target: {fileID: 5414948161102384397, guid: 976393b12d96e344a9dcb7616b6b887b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5414948161102384399, guid: 976393b12d96e344a9dcb7616b6b887b,
         type: 3}
@@ -919,7 +1008,7 @@ PrefabInstance:
     - target: {fileID: 5414948161102384399, guid: 976393b12d96e344a9dcb7616b6b887b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5414948161102384399, guid: 976393b12d96e344a9dcb7616b6b887b,
         type: 3}
@@ -983,7 +1072,7 @@ PrefabInstance:
     - target: {fileID: 7436101132885174641, guid: 0d2599c5ce7c7dd40a0381a114ddd5a8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7436101132885174641, guid: 0d2599c5ce7c7dd40a0381a114ddd5a8,
         type: 3}
@@ -1014,6 +1103,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 7436101132885174646, guid: 0d2599c5ce7c7dd40a0381a114ddd5a8,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0d2599c5ce7c7dd40a0381a114ddd5a8, type: 3}
@@ -1114,6 +1208,11 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 11
       objectReference: {fileID: 0}
+    - target: {fileID: 7953915783607088886, guid: d322b4602c8e9434ebf2a1ba514f02de,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1152,7 +1251,7 @@ PrefabInstance:
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7953915783607088890, guid: d322b4602c8e9434ebf2a1ba514f02de,
         type: 3}
@@ -1251,3 +1350,77 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2132872378}
   m_CullTransparentMesh: 0
+--- !u!1001 &1017543785137101700
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023099, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023103, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_Name
+      value: Explosive Crate
+      objectReference: {fileID: 0}
+    - target: {fileID: 1017543783673023103, guid: 912f1e874723a42ec8d785b59e3ea6bb,
+        type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 912f1e874723a42ec8d785b59e3ea6bb, type: 3}

--- a/Shooter Tutorial/Assets/Scripts/EnemyScripts/Enemy1.cs
+++ b/Shooter Tutorial/Assets/Scripts/EnemyScripts/Enemy1.cs
@@ -35,6 +35,7 @@ public class Enemy1 : MonoBehaviour
     private float max_move_speed;
     private bool effects;
     private float length_of_effect;
+    private bool knockBackEffect;
 
 
     Vector2 direction;
@@ -66,18 +67,19 @@ public class Enemy1 : MonoBehaviour
     }
     private void Start()
     {
-        
+
         // We need to find the player so we can move toward them
         player = GameObject.FindGameObjectWithTag("Player").GetComponent<Player>();
         seeker = GetComponent<Seeker>();
         InvokeRepeating("UpdatePath", 0f, .5f);
         max_move_speed = move_speed;
+        knockBackEffect = false;
     }
 
     private void Update()
     {
         look();
-        if(att_timer > 0)
+        if (att_timer > 0)
         {
             att_timer -= Time.deltaTime;
         }
@@ -96,16 +98,18 @@ public class Enemy1 : MonoBehaviour
 
     private void FixedUpdate()
     {
-        
 
-        if(path == null)
+
+        if (path == null)
         {
             return;
         }
 
-        Move();
+        if (!knockBackEffect)
+        {
+            Move();
+        }
 
-       
     }
     #endregion
 
@@ -114,18 +118,19 @@ public class Enemy1 : MonoBehaviour
     void UpdatePath()
     {
 
-        if (seeker.IsDone()) {
+        if (seeker.IsDone())
+        {
             seeker.StartPath(enemyRB.position, player.transform.position, OnPathComplete);
         }
     }
 
     private void look()
     {
-        
-        transform.up = (Vector2) player.transform.position - enemyRB.position;
-        
-        
-    } 
+
+        transform.up = (Vector2)player.transform.position - enemyRB.position;
+
+
+    }
 
     private void Move()
     {
@@ -135,22 +140,29 @@ public class Enemy1 : MonoBehaviour
         reachedEndofPath = false;
         // The distance to the next waypoint in the path
         float distanceToWaypoint;
-        while (true) {
+        while (true)
+        {
             // If you want maximum performance you can check the squared distance instead to get rid of a
             // square root calculation. But that is outside the scope of this tutorial.
             distanceToWaypoint = Vector3.Distance(enemyRB.position, path.vectorPath[currWaypoint]);
-            //Debug.Log("distanceToWayPoint: " + distanceToWaypoint);
-            if (distanceToWaypoint < nextWaypointDistance) {
+            Debug.Log("distanceToWayPoint: " + distanceToWaypoint);
+            if (distanceToWaypoint < nextWaypointDistance)
+            {
                 // Check if there is another waypoint or if we have reached the end of the path
-                if (currWaypoint + 1 < path.vectorPath.Count) {
+                if (currWaypoint + 1 < path.vectorPath.Count)
+                {
                     currWaypoint++;
-                } else {
+                }
+                else
+                {
                     // Set a status variable to indicate that the agent has reached the end of the path.
                     // You can use this to trigger some special code if your game requires that.
                     reachedEndofPath = true;
                     break;
                 }
-            } else {
+            }
+            else
+            {
                 break;
             }
         }
@@ -178,7 +190,7 @@ public class Enemy1 : MonoBehaviour
         Debug.Log("collided");
         if (collision.transform.CompareTag("Player"))
         {
-            if(att_timer <= 0)
+            if (att_timer <= 0)
             {
                 Debug.Log("attacking");
                 collision.gameObject.GetComponent<Player>().TakeDamage(dmg);
@@ -191,7 +203,7 @@ public class Enemy1 : MonoBehaviour
     #region AI_funcs
     void OnPathComplete(Path P)
     {
-        
+
         if (!P.error)
         {
             path = P;
@@ -206,17 +218,27 @@ public class Enemy1 : MonoBehaviour
     public void TakeDamage(float d)
     {
         CurrHealth -= d;
-        if(CurrHealth <= 0)
+        if (CurrHealth <= 0)
         {
             Debug.Log("Added Points");
             Destroy(this.gameObject);
         }
     }
 
-    public void SetEffects(bool setting, float timer)
+
+    #endregion
+
+    #region Effects
+
+    public void SetEffects(bool setting, float timer, string effect = "not knockback")
     {
         effects = setting;
         length_of_effect = timer;
+
+        if (effect == "knockback")
+        {
+            knockBackEffect = true;
+        }
     }
 
     public bool EffectsOn()
@@ -229,6 +251,7 @@ public class Enemy1 : MonoBehaviour
         Debug.Log("Timer Works");
         GetComponent<Enemy1>().move_speed = max_move_speed;
         GetComponent<SpriteRenderer>().color = Color.white;
+        knockBackEffect = false;
     }
     #endregion
 

--- a/Shooter Tutorial/Assets/Scripts/ExplosiveCrate.cs
+++ b/Shooter Tutorial/Assets/Scripts/ExplosiveCrate.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ExplosiveCrate : MonoBehaviour
+{
+    public float blastRadius;
+    public LayerMask enemyLayer;
+    public int damage;
+    public float explosionForce;
+    public float knockBackDistance;
+    private string nameOfEffect = "knockback";
+
+
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.gameObject.tag == "Bullet")
+        {
+            Explode();
+            Destroy(this.gameObject);
+        }
+    }
+
+    private void OnDrawGizmos()
+    {
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, blastRadius);
+    }
+
+
+    private void Explode()
+    {
+        Collider2D[] enemiesWithinBlastRadius = Physics2D.OverlapCircleAll(transform.position, blastRadius, enemyLayer);
+
+        if (enemiesWithinBlastRadius.Length >= 1)
+        {
+            Debug.Log("Explode");
+            for (int i = 0; i < enemiesWithinBlastRadius.Length; i++)
+            {
+                Rigidbody2D currEnemyRB = enemiesWithinBlastRadius[i].GetComponent<Rigidbody2D>();
+                enemiesWithinBlastRadius[i].GetComponent<Enemy1>().TakeDamage(damage);
+                enemiesWithinBlastRadius[i].GetComponent<Enemy1>().SetEffects(true, knockBackDistance, nameOfEffect);
+                KnockBack(currEnemyRB);
+            }
+        }
+    }
+
+    private void KnockBack(Rigidbody2D enemyRB)
+    {
+        Vector2 direction = enemyRB.transform.position - transform.position;
+        enemyRB.AddForce(direction.normalized * explosionForce, ForceMode2D.Impulse);
+    }
+}

--- a/Shooter Tutorial/Assets/Scripts/PlayerScripts/BasicMeleeAttack.cs
+++ b/Shooter Tutorial/Assets/Scripts/PlayerScripts/BasicMeleeAttack.cs
@@ -24,6 +24,7 @@ public class BasicMeleeAttack : MonoBehaviour
             for (int i = 0; i < enemiesInRange.Length; i++)
             {
                 enemiesInRange[i].GetComponent<Enemy1>().TakeDamage(damage);
+                enemiesInRange[i].GetComponent<Enemy1>().SetEffects(true, 0.2f, "knockback");
                 KnockBack(enemiesInRange[i].GetComponent<Rigidbody2D>());
             }
         }
@@ -33,7 +34,7 @@ public class BasicMeleeAttack : MonoBehaviour
     void KnockBack(Rigidbody2D enemy)
     {
         Vector3 direction = enemy.transform.position - transform.position;
-        enemy.AddForce(direction * knockBackEffectStrength);
+        enemy.AddForce(direction * knockBackEffectStrength, ForceMode2D.Impulse);
     }
 
     // Visual for the area of effect for the melee attack

--- a/Shooter Tutorial/ProjectSettings/TagManager.asset
+++ b/Shooter Tutorial/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Enemy
   - Wall
   - ShooterEnemy
+  - Bullet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Added Explosive Crate script and prefab. It can be pushed around and explodes when ANY bullet hits it. The knockback effect looks smoother for both the Explosive Crate and BasicMeleeAttack. You can test these out in the UItests 1 scene.